### PR TITLE
Refactor attack hitbox connections

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -196,22 +196,26 @@ func _spawn_attack_hitbox() -> void:
 	else:
 		add_child(area)
 
-	# Remove o hitbox automaticamente após curto intervalo
-	get_tree().create_timer(0.1).timeout.connect(func():
-		if is_instance_valid(area):
-			area.queue_free()
-	)
+        # Remove o hitbox automaticamente após curto intervalo
+        var timer := get_tree().create_timer(0.1)
+        timer.timeout.connect(_on_attack_hitbox_timeout.bind(area))
 
-	area.body_entered.connect(func(body):
-		if body is Enemy:
-			body.take_damage(34)
-			if main and main.has_method("play_sfx_id"):
-				main.play_sfx_id("hit")
-			if main and main.has_method("show_damage_popup_at_world"):
-				main.show_damage_popup_at_world(body.global_position, "-34", Color(1, 0.8, 0.2, 1))
-		if is_instance_valid(area):
-			area.queue_free()
-	)
+        area.body_entered.connect(_on_attack_hitbox_body_entered.bind(area))
+
+func _on_attack_hitbox_timeout(hitbox: Area2D) -> void:
+        if is_instance_valid(hitbox):
+                hitbox.queue_free()
+
+func _on_attack_hitbox_body_entered(body: Node, hitbox: Area2D) -> void:
+        if body is Enemy:
+                body.take_damage(34)
+                # play SFX / show popup via `main`
+                if main and main.has_method("play_sfx_id"):
+                        main.play_sfx_id("hit")
+                if main and main.has_method("show_damage_popup_at_world"):
+                        main.show_damage_popup_at_world(body.global_position, "-34", Color(1, 0.8, 0.2, 1))
+        if is_instance_valid(hitbox):
+                hitbox.queue_free()
 
 func take_damage(amount: int) -> void:
 	if main and main.has_method("damage_player"):


### PR DESCRIPTION
## Summary
- Use bound callables for attack hitbox timer and collision signals
- Add helper methods to clean up hitbox after timeout or collision

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a88ec240188326b4e55b9ba695de73