### PR TITLE
Use tabs for attack hitbox indentation

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -196,26 +196,26 @@ func _spawn_attack_hitbox() -> void:
 	else:
 		add_child(area)
 
-        # Remove o hitbox automaticamente após curto intervalo
-        var timer := get_tree().create_timer(0.1)
-        timer.timeout.connect(_on_attack_hitbox_timeout.bind(area))
+	# Remove o hitbox automaticamente após curto intervalo
+	var timer := get_tree().create_timer(0.1)
+	timer.timeout.connect(_on_attack_hitbox_timeout.bind(area))
 
-        area.body_entered.connect(_on_attack_hitbox_body_entered.bind(area))
+	area.body_entered.connect(_on_attack_hitbox_body_entered.bind(area))
 
 func _on_attack_hitbox_timeout(hitbox: Area2D) -> void:
-        if is_instance_valid(hitbox):
-                hitbox.queue_free()
+	if is_instance_valid(hitbox):
+		hitbox.queue_free()
 
 func _on_attack_hitbox_body_entered(body: Node, hitbox: Area2D) -> void:
-        if body is Enemy:
-                body.take_damage(34)
-                # play SFX / show popup via `main`
-                if main and main.has_method("play_sfx_id"):
-                        main.play_sfx_id("hit")
-                if main and main.has_method("show_damage_popup_at_world"):
-                        main.show_damage_popup_at_world(body.global_position, "-34", Color(1, 0.8, 0.2, 1))
-        if is_instance_valid(hitbox):
-                hitbox.queue_free()
+	if body is Enemy:
+		body.take_damage(34)
+		# play SFX / show popup via `main`
+		if main and main.has_method("play_sfx_id"):
+		        main.play_sfx_id("hit")
+		if main and main.has_method("show_damage_popup_at_world"):
+		        main.show_damage_popup_at_world(body.global_position, "-34", Color(1, 0.8, 0.2, 1))
+	if is_instance_valid(hitbox):
+		hitbox.queue_free()
 
 func take_damage(amount: int) -> void:
 	if main and main.has_method("damage_player"):


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in Player's attack hitbox functions

## Testing
- `rg '^ ' -n scripts/player.gd`
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ba62be88326a00c934d90fe13ff